### PR TITLE
fix title-overlay in chrome devtool setting page

### DIFF
--- a/app/styles/panel.scss
+++ b/app/styles/panel.scss
@@ -115,8 +115,8 @@ input[type="range"]::-webkit-slider-runnable-track {
   top: 50%;
   left: 50%;
   text-align: center;
-  margin: -14em 0 0 -20%;
-  width: 40%;
+  transform: translate(-50%, -50%);
+  min-width: 40%;
 
   h1, h2, h3, h4, h5, h6 {
     font-weight: normal;
@@ -134,10 +134,6 @@ input[type="range"]::-webkit-slider-runnable-track {
       font-weight: 300;
       letter-spacing: 0.05em;
     }
-  }
-
-  .title {
-    height: 9.85em;
   }
 
   h1 {


### PR DESCRIPTION
change the centering style, and remove useless height limit.

this fix #72 & #70 