### PR TITLE
Highlight line color

### DIFF
--- a/app/styles/themes/monokai.scss
+++ b/app/styles/themes/monokai.scss
@@ -19,6 +19,6 @@ $dark-theme: true;
 #F92672, // CSS Keywords (!important, etc.)
 #F92672, // HTML Tags / CSS ID/Class Selectors / JS Keywords
 #E6DB74, // HTML/CSS/JS Strings
-#F92672, // CSS Tag Selectors / JS Operators (in Canary)
+#2F2F25, // CSS Tag Selectors / JS Operators (in Canary)
 #A6E22E  // Accent / Highlight
 );


### PR DESCRIPTION
Sublime's `"highlight_line": true,` settings gives `#2F2F25` as background colors for selected line.