### PR TITLE
Fixes cropped tab titles when opening to the Styles tab 🎉

### DIFF
--- a/app/styles/modules/_common-styles.scss
+++ b/app/styles/modules/_common-styles.scss
@@ -434,7 +434,7 @@ $accent                 // Accent / Highlight
 
             .tabbed-pane-header-tab-title {
               box-sizing: content-box;
-              padding: 0 8px;
+              padding: 0;
             }
 
             &.selected {

--- a/app/styles/modules/_common-styles.scss
+++ b/app/styles/modules/_common-styles.scss
@@ -360,9 +360,10 @@ $accent                 // Accent / Highlight
         margin-left: 12px;
 
         .tabbed-pane-header-tab {
-          font-size: 10px;
+          font-size: 12px;
           height: 28px;
           padding: 6px 12px !important;
+          width: auto !important;
         }
       }
     }


### PR DESCRIPTION
### - Summary
This PR adds fixes the right tab labels to no longer crop (when opening Dev Tools to the Styles pane.

Attempted fix for #150 

#### Before:
![Before](https://cldup.com/_5e79eyisA.png)

#### After:
![After](https://cldup.com/EP8sOoxatd.png)
